### PR TITLE
Fixed URL encoding to work with modern Thumbor version, that somehow …

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,9 @@
             height || (height = '0');
             method = method && (method + "/") || '';
             call = "" + method + width + "x" + height + "/" + this.originalUrl;
+            // Thumbors URL loder has issues with ? in URLs, see https://github.com/thumbor/thumbor/issues/331
+            // hence the url encoding here:
+            call.replace('?', '%3F')
             token = CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA1(call, this.signingKey));
             token = token.replace(/\+/g, '-');
             token = token.replace(/\//g, '_');


### PR DESCRIPTION
…don't allow question marks (?) in URLs.